### PR TITLE
Redirect HTTP to HTTPS on ALB by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,7 +106,13 @@ resource "aws_lb_listener" "http" {
 
   default_action {
     target_group_arn = "${aws_lb_target_group.default.arn}"
-    type             = "forward"
+    type             = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
   }
 }
 


### PR DESCRIPTION
* This will redirect incoming requests for HTTP to HTTPS by default
* This should be default for all applications we can terminate SSL at the load balancer 
* Individual HTTPS redirects will need to be configured using the tf-mod-alb-ingress module