### PR TITLE
TF v0.13 upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 env:
-  - TF_VERSION=0.12.9
+  - TF_VERSION=0.13.7
 before_install:
   - wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip -O /tmp/tf.zip
   - unzip -d bin/ /tmp/tf.zip

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 }
 
 module "default_label" {
-  source = "github.com/mitlibraries/tf-mod-name?ref=0.12"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.13"
   name   = var.name
   tags   = var.tags
 }
@@ -50,15 +50,16 @@ resource "aws_security_group_rule" "https_ingress" {
 /*
 module "access_logs" {
   source     = "git::https://github.com/cloudposse/terraform-aws-lb-s3-bucket.git?ref=tags/0.1.0"
-  attributes = "${var.attributes}"
-  delimiter  = "${var.delimiter}"
-  name       = "${var.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  tags       = "${var.tags}"
-  region     = "${var.access_logs_region}"
+  attributes = var.attributes
+  delimiter  = var.delimiter
+  name       = var.name
+  namespace  = var.namespace
+  stage      = var.stage
+  tags       = var.tags
+  region     = var.access_logs_region
 }
 */
+
 resource "aws_lb" "default" {
   name               = module.default_label.name
   tags               = module.default_label.tags
@@ -75,9 +76,9 @@ resource "aws_lb" "default" {
   enable_deletion_protection       = var.deletion_protection_enabled
   /*
   access_logs {
-    bucket  = "${module.access_logs.bucket_id}"
-    prefix  = "${var.access_logs_prefix}"
-    enabled = "${var.access_logs_enabled}"
+    bucket  = module.access_logs.bucket_id
+    prefix  = var.access_logs_prefix
+    enabled = var.access_logs_enabled
   }
   */
 }
@@ -136,4 +137,3 @@ resource "aws_lb_listener" "https" {
     type             = "forward"
   }
 }
-

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }


### PR DESCRIPTION
Developer Checklist

  - [X ]  The README contains the correct list of dependencies, inputs, and outputs (e.g., terraform-docs markdown . has been run)
  - [NA] Latest versions of stage.tfvars and prod.tfvars uploaded to mit-tfvars S3 bucket
  - [NA] Stakeholder approval has been confirmed (or is not needed)
  - [N/A] Resources currently deploy to stage workspace

A terraform plan should show Plan: 6 to add, 0 to change, 0 to destroy.

What does this PR do?
This PR updates the Terraform code for tf-mod-alb to Terraform v0.13.

Helpful background context
The specific changes to this code include updating the required Terraform version in versions.tf to 0.13, modifying the code to pull the v0.13 tagged version of tf-mod-name, the Travis build file was reconfigured to pull Terraform v0.13.7 (the last version of the v0.13 branch, and finally migrating some commented out code related to logging from Terraform v0.11 format to v0.13 format.

Requires Database Migrations?
NO

Includes new or updated dependencies?
NO